### PR TITLE
Fast indexing

### DIFF
--- a/deep.lua
+++ b/deep.lua
@@ -26,8 +26,6 @@ local deep = {
 }
 
 local execQueue = {}
-local maxIndex = 1
-local minIndex = 1
 
 -- for compatibility with Lua 5.1/5.2
 local unpack = rawget(table, "unpack") or unpack
@@ -44,13 +42,7 @@ deep.queue = function(i, fun, ...)
   end
 
   local arg = { ... }
-
-  if i < minIndex then
-    minIndex = i
-  elseif i > maxIndex then
-    maxIndex = i
-  end
-
+  
   if arg and #arg > 0 then
     local t = function() return fun(unpack(arg)) end
 
@@ -69,15 +61,23 @@ deep.queue = function(i, fun, ...)
 end
 
 deep.execute = function()
-  for i = minIndex, maxIndex do
-    if execQueue[i] then
-      for _, fun in pairs(execQueue[i]) do
+  if next(execQueue) then
+    local keys = {}
+    
+    for k, v in pairs(execQueue) do
+      keys[#keys + 1] = k
+    end
+    
+    table.sort(keys)
+    
+    for k = 1, #keys do
+      for _, fun in ipairs(execQueue[keys[k]]) do
         fun()
       end
     end
+    
+    execQueue = {}
   end
-
-  execQueue = {}
 end
 
 return deep

--- a/deep.lua
+++ b/deep.lua
@@ -26,6 +26,7 @@ local deep = {
 }
 
 local execQueue = {}
+local execKeys = {}
 
 -- for compatibility with Lua 5.1/5.2
 local unpack = rawget(table, "unpack") or unpack
@@ -58,25 +59,22 @@ deep.queue = function(i, fun, ...)
       table.insert(execQueue[i], fun)
     end
   end
+  
+  table.insert(execKeys, i)
 end
 
 deep.execute = function()
   if next(execQueue) ~= nil then
-    local keys = {}
+    table.sort(execKeys)
     
-    for k, v in pairs(execQueue) do
-      keys[#keys + 1] = k
-    end
-    
-    table.sort(keys)
-    
-    for k = 1, #keys do
-      for i = 1, #execQueue[keys[k]] do
-        execQueue[keys[k]][i]()
+    for k = 1, #execKeys do
+      for i = 1, #execQueue[execKeys[k]] do
+        execQueue[execKeys[k]][i]()
       end
     end
     
     execQueue = {}
+    execKeys = {}
   end
 end
 

--- a/deep.lua
+++ b/deep.lua
@@ -71,8 +71,8 @@ deep.execute = function()
     table.sort(keys)
     
     for k = 1, #keys do
-      for _, fun in ipairs(execQueue[keys[k]]) do
-        fun()
+      for i = 1, #execQueue[keys[k]] do
+        execQueue[keys[k]][i]()
       end
     end
     

--- a/deep.lua
+++ b/deep.lua
@@ -61,7 +61,7 @@ deep.queue = function(i, fun, ...)
 end
 
 deep.execute = function()
-  if next(execQueue) then
+  if next(execQueue) ~= nil then
     local keys = {}
     
     for k, v in pairs(execQueue) do


### PR DESCRIPTION
`deep.execute` will sort queues by keys instead of iterating from min to max indexes.
This is no longer a performance issue:
```
deep.queue(-10000, print, "Large negative!")
deep.queue(1, print, "Normal")
deep.queue(10000, print, "Large positive!")
deep.queue(-20.32471, print, "Wild card!")
deep.execute()
```